### PR TITLE
Better license detection, fallbacks, normalisation & edn output

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject arre/lein-licenses "0.2.0"
   :description "List the license of each of your dependencies."
-  :url "https://github.com/technomancy/lein-licenses"
+  :url "https://github.com/arre/lein-licenses"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-licenses "0.1.1"
+(defproject arre/lein-licenses "0.1.1-SNAPSHOT"
   :description "List the license of each of your dependencies."
   :url "https://github.com/technomancy/lein-licenses"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject arre/lein-licenses "0.2.0"
+(defproject lein-licenses "0.1.1"
   :description "List the license of each of your dependencies."
-  :url "https://github.com/arre/lein-licenses"
+  :url "https://github.com/technomancy/lein-licenses"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject arre/lein-licenses "0.1.1-SNAPSHOT"
+(defproject arre/lein-licenses "0.2.0"
   :description "List the license of each of your dependencies."
   :url "https://github.com/technomancy/lein-licenses"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/licenses.clj
+++ b/src/leiningen/licenses.clj
@@ -30,7 +30,7 @@
       (xml/parse file))
     (catch Exception e
       (binding [*out* *err*]
-        (println "#   " (str groupId) (groupId artifactId) (class e) (.getMessage e))))))
+        (println "#   " (str groupId) (str artifactId) (class e) (.getMessage e))))))
 
 (defn- get-parent [pom]
   (if-let [parent-tag (->> pom

--- a/src/leiningen/licenses.clj
+++ b/src/leiningen/licenses.clj
@@ -73,7 +73,11 @@
   (try
     (if-let [entry (some (partial get-entry file) license-file-names)]
       (with-open [rdr (io/reader (.getInputStream file entry))]
-        (string/trim (first (remove string/blank? (line-seq rdr))))))
+        (->> rdr
+             line-seq
+             (remove string/blank?)
+             first
+             string/trim)))
     (catch Exception e
       (binding [*out* *err*]
         (println "#   " (str file) (class e) (.getMessage e))))))


### PR DESCRIPTION
First of all, please excuse me for making a kitchen sink-style PR. If you want it to be broken up into separate PRs I probably can do that.

Changes:

* Fixed NPE when we can’t locate a license.
* Changed `fetch-pom` to use repositories specified in `project.clj` (i.e. clojars)
* Added `<artifact>.pom` (+ parents) to the files we check. This helps with libraries that don’t have `pom.xml` in the jar.
* Added support for fallbacks to cover the case where we failed to locate any license information.
* Added license name normalisation and synonyms detection (i.e. `"Eclipse Public License" "Eclipse Public License 1.0" "EPL"` => `"EPL 1.0"`).
* Changed output functions to process everything in one pass instead of per-line.
* Added `edn` to the list of output formats to make automated processing a bit easier.
* Added some mess to the code.

I’m not sure on how to handle fallback & synonyms lists properly and if I should add some pre-set synonyms to the package. Haven’t updated the docs yet but totally will do that after review.

Thank you!